### PR TITLE
FAQ removed for now

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,7 +52,7 @@ nav:
   #   - Talks: schedule/talks.md
   - Instructions: instructions.md
   #- Social Events: social_events.md
-  - FAQ: faq.md
+  #- FAQ: faq.md
   #- Sponsors:
   #  - our-sponsors.md
 plugins:


### PR DESCRIPTION
## Summary by Sourcery

Documentation:
- Commented out the FAQ page in the navigation menu