### PR TITLE
Updated hotel info based on comm. with Sonesta

### DIFF
--- a/docs/useful_info.md
+++ b/docs/useful_info.md
@@ -18,9 +18,8 @@ Facilities commonly used by SETI visitors include:
 
 * [Sonesta ES Suites Sunnyvale – 900 Hamlin Ct, Sunnyvale, CA 94089](https://www.sonesta.com/sonesta-es-suites/ca/sunnyvale/sonesta-es-suites-sunnyvale)
 
-SETI institute has a negotiated rate with Sonesta, currently at $189 + tax/fees for a single suite and $229 for a double suite.
+SETI institute has a negotiated rate with Sonesta, currently at $189 + tax/fees for a single suite and $229 for a double suite for a limited number of rooms.
 The price can only be warranted if the booking is made up to 30 days prior to the meeting. Participants will receive a booking code upon request.
-Participants will receive a booking code upon request.
 
 * [Larkspur Landing Sunnyvale – 748 N Mathilda Ave, Sunnyvale, CA, 94086](https://www.hotelzico.com/?utm_source=google&utm_medium=organic&utm_campaign=business_listing)
 


### PR DESCRIPTION
## Summary by Sourcery

Update Sonesta hotel information to note limited room availability and remove redundant booking code line.

Documentation:
- Clarify that the negotiated Sonesta rates apply to a limited number of rooms.
- Remove duplicate line about participants receiving a booking code on request.