### PR TITLE
Fix ake

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,4 +1,5 @@
 [default]
 extend-ignore-identifiers-re = [
     "Instituto",
+    "ake",
 ]

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,6 +46,7 @@ plugins:
       backends:
       - codespell:
           dictionaries: [clear, rare]
+      known_words: [ake, ]
       ignore_code: yes
       min_length: 2
       allow_unicode: no


### PR DESCRIPTION
## Summary by Sourcery

Prevent false positives for the string "ake" in typo checking by adding it to the ignore lists in both the typo configuration and the MkDocs codespell plugin.

Enhancements:
- Add "ake" to the default ignore identifiers in _typos.toml
- Add "ake" to the known_words list in the MkDocs codespell plugin configuration