### PR TITLE
restore reg links

### DIFF
--- a/docs/registration.md
+++ b/docs/registration.md
@@ -4,7 +4,7 @@ title: Registration and Abstract submission
 
 # Attend the Joint MUSE/IRIS science team meeting
 
-## Registration (**CLOSED**)
+## Registration (No Deadline)
 
 !!! warning
 
@@ -15,8 +15,14 @@ title: Registration and Abstract submission
     This will be a MUSE and IRIS science team meeting, directly in support of the operations of the missions, and is NOT a conference.
     Therefore, for NASA funded people, this meeting should not be entered into the NCTS system for approval.
 
-## Abstract submission (**CLOSED**)
+Please fill in the following form:
+
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLScQMnu1V1aOxilhe7mlyeOGI3LQJ4BfwJ-I1pfiPpk5j_87pA/viewform?embedded=true" width="640" height="640" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>
+
+## Abstract submission (No Deadline)
 
 !!! warning
 
     For invited speakers only.
+
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLScibc4uhkEK__UKHeJFEo79ICYymzCMiONYot4DCV3GHUPZuQ/viewform?embedded=true" width="640" height="640" frameborder="0" marginheight="0" marginwidth="0">Loading…</iframe>


### PR DESCRIPTION
## Summary by Sourcery

Restore registration and abstract submission links by updating section headings and embedding the corresponding Google Forms in the documentation

Enhancements:
- Update registration section heading from 'CLOSED' to 'No Deadline' and embed the registration Google Form
- Update abstract submission section heading from 'CLOSED' to 'No Deadline' and embed the abstract submission Google Form

Documentation:
- Embed Google Forms for registration and abstract submission in docs/registration.md