### PR TITLE
Fix some names

### DIFF
--- a/docs/abstracts.md
+++ b/docs/abstracts.md
@@ -140,7 +140,7 @@ Accepted Abstracts.
     </details>
 
 
-* <p id="De Moortel ">**Author**: Ineke De Moortel  <a class="headerlink" href="#De Moortel " title="Permanent link">¶</a>
+* <p id="De Moortel ">**Author**: Ineke De Moortel  <a class="headerlink" href="#De%20Moortel%20" title="Permanent link">¶</a>
 
     **When**: Tuesday - 2:20-2:40
 
@@ -152,7 +152,7 @@ Accepted Abstracts.
     </details>
 
 
-* <p id="De Pontieu">**Author**: Bart De Pontieu <a class="headerlink" href="#De Pontieu" title="Permanent link">¶</a>
+* <p id="De Pontieu">**Author**: Bart De Pontieu <a class="headerlink" href="#De%20Pontieu" title="Permanent link">¶</a>
 
     **When**: Monday - 9:00-9:15
 
@@ -163,7 +163,7 @@ Accepted Abstracts.
     </details>
 
 
-* <p id="Diaz Baso">**Author**: Carlos Jose Diaz Baso <a class="headerlink" href="#Diaz Baso" title="Permanent link">¶</a>
+* <p id="Diaz Baso">**Author**: Carlos Jose Diaz Baso <a class="headerlink" href="#Diaz%20Baso" title="Permanent link">¶</a>
 
     **When**: Thursday - 3:50-4:10
 
@@ -440,7 +440,7 @@ Atmosphere </summary>
     </details>
 
 
-* <p id="Martínez-Sykora">**Author**: Juan Martínez-Sykora <a class="headerlink" href="#Martínez-Sykora" title="Permanent link">¶</a>
+* <p id="Martínez-Sykora">**Author**: Juan Martínez-Sykora <a class="headerlink" href="#Mart%C3%ADnez-Sykora" title="Permanent link">¶</a>
 
     **When**: Wednesday - 2:20-2:40
 
@@ -475,7 +475,7 @@ Atmosphere </summary>
     </details>
 
 
-* <p id="Nóbrega-Siverio">**Author**: Daniel Nóbrega-Siverio <a class="headerlink" href="#Nóbrega-Siverio" title="Permanent link">¶</a>
+* <p id="Nóbrega-Siverio">**Author**: Daniel Nóbrega-Siverio <a class="headerlink" href="#N%C3%B3brega-Siverio" title="Permanent link">¶</a>
 
     **When**: Wednesday - 9:50-10:10
 
@@ -587,7 +587,7 @@ Atmosphere </summary>
     </details>
 
 
-* <p id="Rouppe van der Voort">**Author**: Luc Rouppe van der Voort <a class="headerlink" href="#Rouppe van der Voort" title="Permanent link">¶</a>
+* <p id="Rouppe van der Voort">**Author**: Luc Rouppe van der Voort <a class="headerlink" href="#Rouppe%20van%20der%20Voort" title="Permanent link">¶</a>
 
     **When**: Wednesday - 1:20-1:40
 
@@ -598,7 +598,7 @@ Atmosphere </summary>
     </details>
 
 
-* <p id="Sainz Dalda">**Author**: Alberto Sainz Dalda <a class="headerlink" href="#Sainz Dalda" title="Permanent link">¶</a>
+* <p id="Sainz Dalda">**Author**: Alberto Sainz Dalda <a class="headerlink" href="#Sainz%20Dalda" title="Permanent link">¶</a>
 
     **When**: Wednesday - 2:40-3:00
 
@@ -697,7 +697,7 @@ Atmosphere </summary>
     </details>
 
 
-* <p id="de la Cruz Rodriguez">**Author**: Jaime de la Cruz Rodriguez <a class="headerlink" href="#de la Cruz Rodriguez" title="Permanent link">¶</a>
+* <p id="de la Cruz Rodriguez">**Author**: Jaime de la Cruz Rodriguez <a class="headerlink" href="#de%20la%20Cruz%20Rodriguez" title="Permanent link">¶</a>
 
     **When**: Wednesday - 11:50-12:20
 

--- a/docs/assets/files/create_md_abstract_list.py
+++ b/docs/assets/files/create_md_abstract_list.py
@@ -1,5 +1,6 @@
 import pandas as pd
 from pathlib import Path
+from urllib.parse import quote
 
 FILE_PATH = "~/Downloads/Abstract submission form (Responses) - Form Responses 1.csv"
 abstracts = pd.read_csv(Path(FILE_PATH).expanduser().resolve())
@@ -31,9 +32,12 @@ abstracts["Abstract (max 300 words)"] = abstracts["Abstract (max 300 words)"].ap
 abstract_data = (
     abstracts.fillna("None").sort_values(by="Last Name").to_dict(orient="records")
 )
+abstract_data = [
+    {**entry, "Last Name Quote": quote(entry["Last Name"])} for entry in abstract_data
+]
 # Below "When" is filled when the schedule is created
 template = """
-* <p id="{Last Name}">**Author**: {First Name} {Last Name} <a class="headerlink" href="#{Last Name}" title="Permanent link">¶</a>
+* <p id="{Last Name}">**Author**: {First Name} {Last Name} <a class="headerlink" href="#{Last Name Quote}" title="Permanent link">¶</a>
 
     **When**: FILL IN
 

--- a/docs/assets/files/create_schedule.py
+++ b/docs/assets/files/create_schedule.py
@@ -2,6 +2,7 @@
 import pandas as pd
 from pathlib import Path
 import inflect
+from urllib.parse import quote
 
 p = inflect.engine()
 
@@ -115,12 +116,30 @@ for _, row in df.iloc[1:].iterrows():
         cells[f"{day}_1"] = row.iloc[base]
         cells[f"{day}_2"] = row.iloc[base + 1]
         cells[f"SESSION_{day}"] = parse_session(row, base + 2)
-        from urllib.parse import quote
-
-        anchor = quote(str(row.iloc[base + 1]))
-        cells[f"{day}_URL"] = (
-            f"https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#{anchor}"
-        )
+        if row.iloc[base + 1] not in [
+            "Lunch break",
+            "Coffee break",
+            "Discussion",
+            "Social Dinner",
+            "Reception",
+            "Close out",
+        ]:
+            # Workaround for Jose Diaz Baso, need to drop Jose
+            if "Jose Diaz Baso" in row.iloc[base + 1]:
+                anchor = quote(
+                    str(row.iloc[base + 1]).replace("Jose Diaz Baso", "Diaz Baso")
+                )
+            elif "Kumar Srivastava" in row.iloc[base + 1]:
+                anchor = quote(
+                    str(row.iloc[base + 1]).replace("Kumar Srivastava", "Srivastava")
+                )
+            else:
+                anchor = quote(str(row.iloc[base + 1]))
+            cells[f"{day}_URL"] = (
+                f"https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#{anchor}"
+            )
+        else:
+            cells[f"{day}_URL"] = ""
     html_rows.append(HTML_TABLE_ROW_TEMPLATE.format(**cells))
 
 HTML_TABLE = HTML_TABLE_TEMPLATE.replace("{BODY}", "\n".join(html_rows))

--- a/docs/schedule.md
+++ b/docs/schedule.md
@@ -30,7 +30,7 @@
 
 <tr>
     <td class="tg-0pky">9:00-9:15</td>
-    <td class="tg-five"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#De Pontieu">De Pontieu</a></td>
+    <td class="tg-five"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#De%20Pontieu">De Pontieu</a></td>
     <td class="tg-0pky">9:00-9:20</td>
     <td class="tg-three"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Fletcher">Fletcher</a></td>
     <td class="tg-0pky">9:00-9:30</td>
@@ -58,7 +58,7 @@
     <td class="tg-0pky">9:40-10:00</td>
     <td class="tg-three"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Kowalski">Kowalski</a></td>
     <td class="tg-0pky">9:50-10:10</td>
-    <td class="tg-two"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Nóbrega-Siverio">Nóbrega-Siverio</a></td>
+    <td class="tg-two"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#N%C3%B3brega-Siverio">Nóbrega-Siverio</a></td>
     <td class="tg-0pky">9:50-10:10</td>
     <td class="tg-one"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Gosic">Gosic</a></td>
 </tr>
@@ -90,13 +90,13 @@
 
 <tr>
     <td class="tg-0pky">10:35-11:05</td>
-    <td class="tg-eight"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Coffee break">Coffee break</a></td>
+    <td class="tg-eight"><a href="">Coffee break</a></td>
     <td class="tg-0pky">10:20-10:50</td>
-    <td class="tg-eight"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Coffee break">Coffee break</a></td>
+    <td class="tg-eight"><a href="">Coffee break</a></td>
     <td class="tg-0pky">10:30-11:00</td>
-    <td class="tg-eight"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Coffee break">Coffee break</a></td>
+    <td class="tg-eight"><a href="">Coffee break</a></td>
     <td class="tg-0pky">10:30-11:00</td>
-    <td class="tg-eight"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Coffee break">Coffee break</a></td>
+    <td class="tg-eight"><a href="">Coffee break</a></td>
 </tr>
 
 
@@ -130,7 +130,7 @@
     <td class="tg-0pky">11:20-12:00</td>
     <td class="tg-seven"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Klimchuk">Klimchuk</a></td>
     <td class="tg-0pky">11:30-11:50</td>
-    <td class="tg-two"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Kumar Srivastava">Kumar Srivastava</a></td>
+    <td class="tg-two"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Srivastava">Kumar Srivastava</a></td>
     <td class="tg-0pky">11:50-12:10</td>
     <td class="tg-four"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Jin">Jin</a></td>
 </tr>
@@ -142,7 +142,7 @@
     <td class="tg-0pky">12:00-12:20</td>
     <td class="tg-two"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Daldorff">Daldorff</a></td>
     <td class="tg-0pky">11:50-12:20</td>
-    <td class="tg-seven"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#de la Cruz Rodriguez">de la Cruz Rodriguez</a></td>
+    <td class="tg-seven"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#de%20la%20Cruz%20Rodriguez">de la Cruz Rodriguez</a></td>
     <td class="tg-0pky">12:10-12:30</td>
     <td class="tg-four"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Upendran">Upendran</a></td>
 </tr>
@@ -150,13 +150,13 @@
 
 <tr>
     <td class="tg-0pky">12:35-1:35</td>
-    <td class="tg-eight"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Lunch break">Lunch break</a></td>
+    <td class="tg-eight"><a href="">Lunch break</a></td>
     <td class="tg-0pky">12:20-1:20</td>
-    <td class="tg-eight"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Lunch break">Lunch break</a></td>
+    <td class="tg-eight"><a href="">Lunch break</a></td>
     <td class="tg-0pky">12:20-1:20</td>
-    <td class="tg-eight"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Lunch break">Lunch break</a></td>
+    <td class="tg-eight"><a href="">Lunch break</a></td>
     <td class="tg-0pky">12:20-1:20</td>
-    <td class="tg-eight"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Lunch break">Lunch break</a></td>
+    <td class="tg-eight"><a href="">Lunch break</a></td>
 </tr>
 
 
@@ -166,7 +166,7 @@
     <td class="tg-0pky">1:20-1:40</td>
     <td class="tg-two"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Antolin">Antolin</a></td>
     <td class="tg-0pky">1:20-1:40</td>
-    <td class="tg-one"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Rouppe van der Voort">Rouppe van der Voort</a></td>
+    <td class="tg-one"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Rouppe%20van%20der%20Voort">Rouppe van der Voort</a></td>
     <td class="tg-0pky">1:20-1:50</td>
     <td class="tg-four"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Brooks">Brooks</a></td>
 </tr>
@@ -200,9 +200,9 @@
     <td class="tg-0pky">2:45-3:05</td>
     <td class="tg-three"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Rempel">Rempel</a></td>
     <td class="tg-0pky">2:20-2:40</td>
-    <td class="tg-two"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#De Moortel">De Moortel</a></td>
+    <td class="tg-two"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#De%20Moortel">De Moortel</a></td>
     <td class="tg-0pky">2:20-2:40</td>
-    <td class="tg-one"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Martínez-Sykora">Martínez-Sykora</a></td>
+    <td class="tg-one"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Mart%C3%ADnez-Sykora">Martínez-Sykora</a></td>
     <td class="tg-0pky">2:30-2:50</td>
     <td class="tg-six"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Glesener">Glesener</a></td>
 </tr>
@@ -214,7 +214,7 @@
     <td class="tg-0pky">2:40-3:00</td>
     <td class="tg-two"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Imada">Imada</a></td>
     <td class="tg-0pky">2:40-3:00</td>
-    <td class="tg-one"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Sainz Dalda">Sainz Dalda</a></td>
+    <td class="tg-one"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Sainz%20Dalda">Sainz Dalda</a></td>
     <td class="tg-0pky">2:50-3:10</td>
     <td class="tg-six"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Jaeggli">Jaeggli</a></td>
 </tr>
@@ -222,13 +222,13 @@
 
 <tr>
     <td class="tg-0pky">3:05-3:35</td>
-    <td class="tg-eight"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Coffee break">Coffee break</a></td>
+    <td class="tg-eight"><a href="">Coffee break</a></td>
     <td class="tg-0pky">3:00-3:30</td>
-    <td class="tg-eight"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Coffee break">Coffee break</a></td>
+    <td class="tg-eight"><a href="">Coffee break</a></td>
     <td class="tg-0pky">3:00-3:30</td>
-    <td class="tg-eight"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Coffee break">Coffee break</a></td>
+    <td class="tg-eight"><a href="">Coffee break</a></td>
     <td class="tg-0pky">3:00-3:30</td>
-    <td class="tg-eight"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Coffee break">Coffee break</a></td>
+    <td class="tg-eight"><a href="">Coffee break</a></td>
 </tr>
 
 
@@ -248,11 +248,11 @@
     <td class="tg-0pky">3:55-4:15</td>
     <td class="tg-three"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Ferrente">Ferrente</a></td>
     <td class="tg-0pky">3:50-4:10</td>
-    <td class="tg-two"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Franco Rappazzo">Franco Rappazzo</a></td>
+    <td class="tg-two"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Franco%20Rappazzo">Franco Rappazzo</a></td>
     <td class="tg-0pky">3:50-4:10</td>
     <td class="tg-one"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Stangalini">Stangalini</a></td>
     <td class="tg-0pky">3:50-4:10</td>
-    <td class="tg-six"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Jose Diaz Baso">Jose Diaz Baso</a></td>
+    <td class="tg-six"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Diaz%20Baso">Jose Diaz Baso</a></td>
 </tr>
 
 
@@ -262,17 +262,17 @@
     <td class="tg-0pky">4:10-4:30</td>
     <td class="tg-two"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Tripathi">Tripathi</a></td>
     <td class="tg-0pky">4:10-5:00</td>
-    <td class="tg-zero"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Discussion">Discussion</a></td>
+    <td class="tg-zero"><a href="">Discussion</a></td>
     <td class="tg-0pky">4:10-5:00</td>
-    <td class="tg-zero"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Close out">Close out</a></td>
+    <td class="tg-zero"><a href="">Close out</a></td>
 </tr>
 
 
 <tr>
     <td class="tg-0pky">4:35-5:00</td>
-    <td class="tg-zero"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Discussion">Discussion</a></td>
+    <td class="tg-zero"><a href="">Discussion</a></td>
     <td class="tg-0pky">4:30-5:00</td>
-    <td class="tg-zero"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Discussion">Discussion</a></td>
+    <td class="tg-zero"><a href="">Discussion</a></td>
     <td class="tg-0pky"></td>
     <td class="tg-zero"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#"></a></td>
     <td class="tg-0pky"></td>
@@ -282,11 +282,11 @@
 
 <tr>
     <td class="tg-0pky">TBD</td>
-    <td class="tg-eight"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Reception">Reception</a></td>
+    <td class="tg-eight"><a href="">Reception</a></td>
     <td class="tg-0pky"></td>
     <td class="tg-zero"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#"></a></td>
     <td class="tg-0pky">TBD</td>
-    <td class="tg-eight"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#Social Dinner">Social Dinner</a></td>
+    <td class="tg-eight"><a href="">Social Dinner</a></td>
     <td class="tg-0pky"></td>
     <td class="tg-zero"><a href="https://lm-sal.github.io/iris_muse_team_meeting/abstracts/#"></a></td>
 </tr>


### PR DESCRIPTION
## Summary by Sourcery

Fix encoding of URL anchors and streamline schedule link generation by updating documentation and the schedule creation script.

Bug Fixes:
- Correct anchor slugs for multi-word and accented names, including special handling for Jose Diaz Baso and Kumar Srivastava.

Enhancements:
- Percent-encode spaces and special characters in schedule link anchors.
- Omit href attributes for non-abstract sessions such as breaks, discussions, and receptions.

Documentation:
- Update schedule.md to use the corrected, percent-encoded anchors and remove links for non-abstract items.

Chores:
- Import urllib.parse.quote and implement conditional URL generation in create_schedule.py.